### PR TITLE
fix(exports): resolve default condition to web build, not React Native

### DIFF
--- a/.changeset/fix-exports-default-web.md
+++ b/.changeset/fix-exports-default-web.md
@@ -1,0 +1,9 @@
+---
+'react-svg-credit-card-payment-icons': patch
+---
+
+Fix the `exports` map so the `default` condition resolves to the web build instead of the React Native build.
+
+Previously the `default` condition for `.` and `./icons/*` pointed at `dist/native/*`. Node, SSR and server-side bundlers (e.g. Next.js server components) do not apply the `browser` condition, so they fell through to `default`, resolved the React Native entry, and failed to build with `Module not found: Can't resolve 'react-native-svg'` — an optional peer dependency that web projects do not install.
+
+`default` now serves the web build. React Native consumers still resolve the native build via the `react-native` condition (set by Metro) or the explicit `./native` subpath.

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "require": "./dist/index.js"
       },
       "default": {
-        "types": "./dist/native/index.d.ts",
-        "import": "./dist/native/index.mjs",
-        "require": "./dist/native/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js"
       }
     },
     "./native": {
@@ -52,9 +52,9 @@
         "require": "./dist/icons/*.js"
       },
       "default": {
-        "types": "./dist/native/icons/*.d.ts",
-        "import": "./dist/native/icons/*.mjs",
-        "require": "./dist/native/icons/*.js"
+        "types": "./dist/icons/*.d.ts",
+        "import": "./dist/icons/*.mjs",
+        "require": "./dist/icons/*.js"
       }
     },
     "./*": {

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Regression guard for the package `exports` map.
+ *
+ * The `default` condition must resolve to the WEB build, never the React
+ * Native build. Node, SSR and server-side bundlers (e.g. Next.js server
+ * components) do not apply the `browser` condition, so when `default`
+ * pointed at `dist/native/*` those consumers resolved the React Native
+ * entry and failed with "Cannot find module 'react-native-svg'" (an
+ * optional peer dependency that web projects do not install).
+ *
+ * React Native consumers still get the native build via the `react-native`
+ * condition (set by Metro) or the explicit `./native` subpath.
+ */
+type ExportTarget = { types: string; import: string; require: string };
+type ConditionalExports = Record<string, ExportTarget>;
+
+const exportsMap = (
+  JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8')) as {
+    exports: Record<string, ConditionalExports | ExportTarget>;
+  }
+).exports;
+
+const isNative = (path: string): boolean => path.includes('/native/');
+
+describe('package.json exports map', () => {
+  describe.each(['.', './icons/*'])('subpath %s', (subpath) => {
+    const entry = exportsMap[subpath] as ConditionalExports;
+
+    it('serves the web build on the default condition (not React Native)', () => {
+      expect(isNative(entry.default.import)).toBe(false);
+      expect(isNative(entry.default.require)).toBe(false);
+      expect(isNative(entry.default.types)).toBe(false);
+    });
+
+    it('still serves the native build on the react-native condition', () => {
+      expect(isNative(entry['react-native'].import)).toBe(true);
+    });
+  });
+
+  it('exposes an explicit ./native entry for React Native consumers', () => {
+    expect(isNative((exportsMap['./native'] as ExportTarget).import)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #25.

## Summary

The `exports` map's `default` condition resolves to the **React Native** build (`dist/native/*`), which hard-imports `react-native-svg`. Any consumer not resolved through the `browser` condition — plain Node, SSR, React Server Components, server-side bundling — falls through to `default`, pulls in the native bundle, and fails because `react-native-svg` is an optional peer dependency that web projects don't install.

Reproduced on a Next.js 16 App Router app: `next build` fails with 108 `Module not found: Can't resolve 'react-native-svg'` errors (one per icon). Minimal Node repro, in a project without `react-native-svg`:

```bash
node -e "require('react-svg-credit-card-payment-icons')"
# → Error: Cannot find module 'react-native-svg'
```

TypeScript's type-check did not surface this — module-resolution conditions at type-check time differ from the server bundler's — so it only appeared at build time.

## Root cause

For `.` and `./icons/*`, `default` pointed at the native build:

```jsonc
".": {
  "react-native": { /* ... */ "import": "./dist/native/index.mjs" },  // native
  "browser":      { /* ... */ "import": "./dist/index.mjs" },         // web
  "default":      { /* ... */ "import": "./dist/native/index.mjs" }   // native  ← problem
}
```

Condition resolution only applies `browser` for client bundles; Node/SSR/server compiles match `default` and land on the native entry. This also contradicted the top-level `main` / `module` / `types` fields, which already point at the web build.

## Fix

Point `default` at the web build for `.` and `./icons/*`. React Native consumers are unaffected — Metro applies the `react-native` condition, and the explicit `./native` subpath remains.

## Tests

Adds `src/exports.test.ts`, a static regression guard asserting `default` serves the web build (not `dist/native/*`) while `react-native` / `./native` stay native. A runtime import test wouldn't catch this — jest resolves from `src`, not via the published `exports` conditions.

Includes a `patch` changeset.
